### PR TITLE
Stick interface for #11

### DIFF
--- a/sense_hat/__init__.py
+++ b/sense_hat/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
 from .sense_hat import SenseHat, SenseHat as AstroPi
+from .stick import SenseStick, InputEvent
 
 __version__ = '2.1.0'

--- a/sense_hat/stick.py
+++ b/sense_hat/stick.py
@@ -1,0 +1,78 @@
+from __future__ import (
+    unicode_literals,
+    absolute_import,
+    print_function,
+    division,
+    )
+native_str = str
+str = type('')
+
+import io
+import os
+import glob
+import errno
+import struct
+import select
+from collections import namedtuple
+from threading import Thread, Event
+
+
+InputEvent = namedtuple('InputEvent', ('timestamp', 'key', 'state'))
+
+
+class SenseStick(object):
+    SENSE_HAT_EVDEV_NAME = 'Raspberry Pi Sense HAT Joystick'
+    EVENT_FORMAT = native_str('llHHI')
+    EVENT_SIZE = struct.calcsize(EVENT_FORMAT)
+
+    EV_KEY = 0x01
+
+    STATE_RELEASE = 0
+    STATE_PRESS = 1
+    STATE_HOLD = 2
+
+    KEY_UP = 103
+    KEY_LEFT = 105
+    KEY_RIGHT = 106
+    KEY_DOWN = 108
+    KEY_ENTER = 28
+
+    def __init__(self):
+        self._stick_file = io.open(self._stick_device(), 'rb')
+
+    def close(self):
+        self._stick_file.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.close()
+
+    def __iter__(self):
+        while True:
+            event = self._stick_file.read(self.EVENT_SIZE)
+            (tv_sec, tv_usec, type, code, value) = struct.unpack(self.EVENT_FORMAT, event)
+            if type == self.EV_KEY:
+                yield InputEvent(tv_sec + (tv_usec / 1000000), code, value)
+
+    def _stick_device(self):
+        for evdev in glob.glob('/sys/class/input/event*'):
+            try:
+                with io.open(os.path.join(evdev, 'device', 'name'), 'r') as f:
+                    if f.read().strip() == self.SENSE_HAT_EVDEV_NAME:
+                        return os.path.join('/dev', 'input', os.path.basename(evdev))
+            except IOError as e:
+                if e.errno != errno.ENOENT:
+                    raise
+        raise RuntimeError('unable to locate SenseHAT joystick device')
+
+    def read(self):
+        return next(iter(self))
+
+    def wait(self, timeout=None):
+        # XXX Use poll() instead?
+        r, w, x = select.select([self._stick_file], [], [], timeout)
+        return bool(r)
+
+


### PR DESCRIPTION
Straight-forward copy of SenseStick into the Sense HAT library with exposure of SenseStick and InputEvent (rename?) in __init__. NOTE: I haven't tested this yet as I'm waiting for numpy to build in a venv on my A+ (might take a while!) but I figured I'd push it anyway in case other people want to give it a whirl.