### PR TITLE
patch returns deep copies of raw inertial sensor dictionaries

### DIFF
--- a/sense_hat/sense_hat.py
+++ b/sense_hat/sense_hat.py
@@ -12,6 +12,7 @@ import pwd
 import array
 import fcntl
 from PIL import Image  # pillow
+from copy import deepcopy
 
 
 class SenseHat(object):
@@ -77,9 +78,9 @@ class SenseHat(object):
         self._humidity_init = False  # Will be initialised as and when needed
         self._last_orientation = {'pitch': 0, 'roll': 0, 'yaw': 0}
         raw = {'x': 0, 'y': 0, 'z': 0}
-        self._last_compass_raw = raw
-        self._last_gyro_raw = raw
-        self._last_accel_raw = raw
+        self._last_compass_raw = deepcopy(raw)
+        self._last_gyro_raw = deepcopy(raw)
+        self._last_accel_raw = deepcopy(raw)
         self._compass_enabled = False
         self._gyro_enabled = False
         self._accel_enabled = False
@@ -482,7 +483,7 @@ class SenseHat(object):
 
     @property
     def gamma(self):
-        buffer = array.array('B', [0]*32) 
+        buffer = array.array('B', [0]*32)
         with open(self._fb_device) as f:
             fcntl.ioctl(f, self.SENSE_HAT_FB_FBIOGET_GAMMA, buffer)
         return list(buffer)
@@ -711,7 +712,7 @@ class SenseHat(object):
             raw['yaw'] = raw.pop('z')
             self._last_orientation = raw
 
-        return self._last_orientation
+        return deepcopy(self._last_orientation)
 
     @property
     def orientation_radians(self):
@@ -763,7 +764,7 @@ class SenseHat(object):
         if raw is not None:
             self._last_compass_raw = raw
 
-        return self._last_compass_raw
+        return deepcopy(self._last_compass_raw)
 
     @property
     def compass_raw(self):
@@ -795,7 +796,7 @@ class SenseHat(object):
         if raw is not None:
             self._last_gyro_raw = raw
 
-        return self._last_gyro_raw
+        return deepcopy(self._last_gyro_raw)
 
     @property
     def gyro_raw(self):
@@ -831,7 +832,7 @@ class SenseHat(object):
         if raw is not None:
             self._last_accel_raw = raw
 
-        return self._last_accel_raw
+        return deepcopy(self._last_accel_raw)
 
     @property
     def accel_raw(self):


### PR DESCRIPTION
I noticed that multiple threads calling get_<sensor>_raw for inertial sensors would be returned a self._last_<sensor> dictionary. A user can modify this dictionary and if self._get_raw_data returns None on subsequent calls to the method, then the user will be returned the modified dictionary. I proposed some changes that return deep copies to prevent users from accidentally modifying underlying class dictionaries that may cause this type of behavior. 

Here is a specific example and stack trace from calling get_orientation_degrees(). If one thread calls get_orientation_radians(), they are returned a shallow copy of the class dictionary that could also be returned by get_orientation_degrees(). This can happen if self._get_raw_data('fusionPoseValid', 'fusionPose') returns None in the get_orientation_radians() method. If the user has modified the dictionary, then get_orientation_degrees() can be returned the modified dictionary. This can result in exceptions or other errors. As an example, deg = Math.degrees(val) can raise a TypeError exception if a non-float value has been added to the self._last_orientation dictionary before get_orientation_degrees() was called. Here is a stack trace:

Exception in thread Thread-7:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "sensor_collector.py", line 262, in stream_orientation_degrees_data
    payload = self.sense.get_orientation_degrees()
  File "/usr/lib/python2.7/dist-packages/sense_hat/sense_hat.py", line 732, in get_orientation_degrees
    deg = math.degrees(val)  # Result is -180 to +180
TypeError: a float is required