### PR TITLE
Implement SenseStick API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -23,6 +23,7 @@ sense.set_rotation(180)
 # alternatives
 sense.rotation = 180
 ```
+
 - - -
 ### flip_h
 
@@ -42,6 +43,7 @@ from sense_hat import SenseHat
 sense = SenseHat()
 sense.flip_h()
 ```
+
 - - -
 ### flip_v
 
@@ -61,6 +63,7 @@ from sense_hat import SenseHat
 sense = SenseHat()
 sense.flip_v()
 ```
+
 - - -
 ### set_pixels
 
@@ -95,6 +98,7 @@ O, O, O, X, O, O, O, O
 
 sense.set_pixels(question_mark)
 ```
+
 - - -
 ### get_pixels
 
@@ -112,6 +116,7 @@ pixel_list = sense.get_pixels()
 Note: You will notice that the pixel values you pass into `set_pixels` sometimes change when you read them back with  `get_pixels`. This is because we specify each pixel element as 8 bit numbers (0 to 255) but when they're passed into the Linux frame buffer for the LED matrix the numbers are bit shifted down to fit into RGB 565. 5 bits for red, 6 bits for green and 5 bits for blue. The loss of binary precision when performing this conversion (3 bits lost for red, 2 for green and 3 for blue) accounts for the discrepancies you see.
 
 The `get_pixels` function provides a correct representation of how the pixels end up in frame buffer memory after you've called `set_pixels`.
+
 - - -
 ### set_pixel
 
@@ -152,6 +157,7 @@ sense.set_pixel(0, 0, red)
 sense.set_pixel(0, 0, green)
 sense.set_pixel(0, 0, blue)
 ```
+
 - - -
 ### get_pixel
 
@@ -172,6 +178,7 @@ top_left_pixel = sense.get_pixel(0, 0)
 ```
 
 Note: Please read the note under `get_pixels`
+
 - - -
 ### load_image
 
@@ -199,6 +206,7 @@ from sense_hat import SenseHat
 sense = SenseHat()
 invader_pixels = sense.load_image("space_invader.png", redraw=False)
 ```
+
 - - -
 ### clear
 
@@ -226,6 +234,7 @@ sense.clear(red)  # passing in an RGB tuple
 sleep(1)
 sense.clear(255, 255, 255)  # passing in r, g and b values of a colour
 ```
+
 - - -
 ### show_message
 
@@ -248,6 +257,7 @@ from sense_hat import SenseHat
 sense = SenseHat()
 sense.show_message("One small step for Pi!", text_colour=[255, 0, 0])
 ```
+
 - - -
 ### show_letter
 
@@ -339,6 +349,7 @@ sense.gamma = [0] * 32  # Will turn the LED matrix off
 time.sleep(2)
 sense.gamma_reset()
 ```
+
 - - -
 ## Environmental sensors
 
@@ -360,6 +371,7 @@ print("Humidity: %s %%rH" % humidity)
 # alternatives
 print(sense.humidity)
 ```
+
 - - -
 ### get_temperature
 
@@ -376,6 +388,7 @@ print("Temperature: %s C" % temp)
 print(sense.temp)
 print(sense.temperature)
 ```
+
 - - -
 ### get_temperature_from_humidity
 
@@ -392,6 +405,7 @@ sense = SenseHat()
 temp = sense.get_temperature_from_humidity()
 print("Temperature: %s C" % temp)
 ```
+
 - - -
 ### get_temperature_from_pressure
 
@@ -408,6 +422,7 @@ sense = SenseHat()
 temp = sense.get_temperature_from_pressure()
 print("Temperature: %s C" % temp)
 ```
+
 - - -
 ### get_pressure
 
@@ -427,6 +442,7 @@ print("Pressure: %s Millibars" % pressure)
 # alternatives
 print(sense.pressure)
 ```
+
 - - -
 ## IMU Sensor
 
@@ -458,6 +474,7 @@ from sense_hat import SenseHat
 sense = SenseHat()
 sense.set_imu_config(False, True, False)  # gyroscope only
 ```
+
 - - -
 ### get_orientation_radians
 
@@ -477,6 +494,7 @@ print("p: {pitch}, r: {roll}, y: {yaw}".format(**orientation_rad))
 # alternatives
 print(sense.orientation_radians)
 ```
+
 - - -
 ### get_orientation_degrees
 
@@ -493,6 +511,7 @@ sense = SenseHat()
 orientation = sense.get_orientation_degrees()
 print("p: {pitch}, r: {roll}, y: {yaw}".format(**orientation))
 ```
+
 - - -
 ### get_orientation
 
@@ -508,6 +527,7 @@ print("p: {pitch}, r: {roll}, y: {yaw}".format(**orientation))
 # alternatives
 print(sense.orientation)
 ```
+
 - - -
 ### get_compass
 
@@ -527,6 +547,7 @@ print("North: %s" % north)
 # alternatives
 print(sense.compass)
 ```
+
 - - -
 ### get_compass_raw
 
@@ -546,6 +567,7 @@ print("x: {x}, y: {y}, z: {z}".format(**raw))
 # alternatives
 print(sense.compass_raw)
 ```
+
 - - -
 ### get_gyroscope
 
@@ -566,6 +588,7 @@ print("p: {pitch}, r: {roll}, y: {yaw}".format(**gyro_only))
 print(sense.gyro)
 print(sense.gyroscope)
 ```
+
 - - -
 ### get_gyroscope_raw
 
@@ -586,6 +609,7 @@ print("x: {x}, y: {y}, z: {z}".format(**raw))
 print(sense.gyro_raw)
 print(sense.gyroscope_raw)
 ```
+
 - - -
 ### get_accelerometer
 
@@ -606,6 +630,7 @@ print("p: {pitch}, r: {roll}, y: {yaw}".format(**accel_only))
 print(sense.accel)
 print(sense.accelerometer)
 ```
+
 - - -
 ### get_accelerometer_raw
 
@@ -626,3 +651,126 @@ print("x: {x}, y: {y}, z: {z}".format(**raw))
 print(sense.accel_raw)
 print(sense.accelerometer_raw)
 ```
+
+- - -
+## Joystick
+
+### InputEvent
+
+A tuple describing a joystick event. Contains three named parameters:
+
+* `timestamp` - The time at which the event occurred, as a fractional number of seconds (the same format as the built-in `time` function)
+
+* `direction` - The direction the joystick was moved, as a string (`"up"`, `"down"`, `"left"`, `"right"`, `"push"`)
+
+* `action` - The action that occurred, as a string (`"pressed"`, `"released"`, `"held"`)
+
+This tuple type is used by several joystick methods either as the return type
+or the type of a parameter.
+
+- - -
+### wait_for_event
+
+Blocks execution until a joystick event occurs, then returns an `InputEvent`
+representing the event that occurred.
+
+```python
+from sense_hat import SenseHat
+from time import sleep
+
+sense = SenseHat()
+event = sense.stick.wait_for_event()
+print("The joystick was {} {}".format(event.action, event.direction))
+sleep(0.1)
+event = sense.stick.wait_for_event()
+print("The joystick was {} {}".format(event.action, event.direction))
+```
+
+In the above example, if you briefly push the joystick in a single direction
+you should see two events output: a pressed action and a released action.
+The optional *emptybuffer* can be used to flush any pending events before
+waiting for new events. Try the following script to see the difference:
+
+```python
+from sense_hat import SenseHat
+from time import sleep
+
+sense = SenseHat()
+event = sense.stick.wait_for_event()
+print("The joystick was {} {}".format(event.action, event.direction))
+sleep(0.1)
+event = sense.stick.wait_for_event(emptybuffer=True)
+print("The joystick was {} {}".format(event.action, event.direction))
+```
+
+- - -
+### get_events
+
+Returns a list of `InputEvent` tuples representing all events that have
+occurred since the last call to `get_events` or `wait_for_event`.
+
+```python
+from sense_hat import SenseHat
+
+sense = SenseHat()
+while True:
+    for event in sense.stick.get_events():
+        print("The joystick was {} {}".format(event.action, event.direction))
+```
+
+- - -
+### direction_up, direction_left, direction_right, direction_down, direction_middle, direction_any
+
+These attributes can be assigned a function which will be called whenever the
+joystick is pushed in the associated direction (or in any direction in the case
+of `direction_any`). The function assigned must either take no parameters or
+must take a single parameter which will be passed the associated `InputEvent`.
+
+```python
+from sense_hat import SenseHat, ACTION_PRESSED, ACTION_HELD, ACTION_RELEASED
+from signal import pause
+
+x = 3
+y = 3
+sense = SenseHat()
+
+def clamp(value, min_value=0, max_value=7):
+    return min(max_value, max(min_value, value))
+
+def pushed_up(event):
+    global y
+    if event.action != ACTION_RELEASED:
+        y = clamp(y - 1)
+
+def pushed_down(event):
+    global y
+    if event.action != ACTION_RELEASED:
+        y = clamp(y + 1)
+
+def pushed_left(event):
+    global x
+    if event.action != ACTION_RELEASED:
+        x = clamp(x - 1)
+
+def pushed_right(event):
+    global x
+    if event.action != ACTION_RELEASED:
+        x = clamp(x + 1)
+
+def refresh():
+    sense.clear()
+    sense.set_pixel(x, y, 255, 255, 255)
+
+sense.stick.direction_up = pushed_up
+sense.stick.direction_down = pushed_down
+sense.stick.direction_left = pushed_left
+sense.stick.direction_right = pushed_right
+sense.stick.direction_any = refresh
+refresh()
+pause()
+```
+
+Note that the `direction_any` event is always called *after* all other events
+making it an ideal hook for things like display refreshing (as in the example
+above).
+

--- a/sense_hat/__init__.py
+++ b/sense_hat/__init__.py
@@ -1,5 +1,16 @@
 from __future__ import absolute_import
 from .sense_hat import SenseHat, SenseHat as AstroPi
-from .stick import SenseStick, InputEvent
+from .stick import (
+    SenseStick,
+    InputEvent,
+    DIRECTION_UP,
+    DIRECTION_DOWN,
+    DIRECTION_LEFT,
+    DIRECTION_RIGHT,
+    DIRECTION_MIDDLE,
+    ACTION_PRESSED,
+    ACTION_RELEASED,
+    ACTION_HELD,
+    )
 
 __version__ = '2.1.0'

--- a/sense_hat/sense_hat.py
+++ b/sense_hat/sense_hat.py
@@ -14,6 +14,8 @@ import fcntl
 from PIL import Image  # pillow
 from copy import deepcopy
 
+from .stick import SenseStick
+
 
 class SenseHat(object):
 
@@ -87,6 +89,7 @@ class SenseHat(object):
         self._compass_enabled = False
         self._gyro_enabled = False
         self._accel_enabled = False
+        self._stick = SenseStick()
 
     ####
     # Text assets
@@ -179,6 +182,14 @@ class SenseHat(object):
                         break
 
         return device
+
+    ####
+    # Joystick
+    ####
+
+    @property
+    def stick(self):
+        return self._stick
 
     ####
     # LED Matrix

--- a/sense_hat/stick.py
+++ b/sense_hat/stick.py
@@ -13,14 +13,30 @@ import glob
 import errno
 import struct
 import select
+import inspect
+from functools import wraps
 from collections import namedtuple
 from threading import Thread, Event
 
 
-InputEvent = namedtuple('InputEvent', ('timestamp', 'key', 'state'))
+DIRECTION_UP     = 'up'
+DIRECTION_DOWN   = 'down'
+DIRECTION_LEFT   = 'left'
+DIRECTION_RIGHT  = 'right'
+DIRECTION_MIDDLE = 'middle'
+
+ACTION_PRESSED  = 'pressed'
+ACTION_RELEASED = 'released'
+ACTION_HELD     = 'held'
+
+
+InputEvent = namedtuple('InputEvent', ('timestamp', 'direction', 'action'))
 
 
 class SenseStick(object):
+    """
+    Represents the joystick on the Sense HAT.
+    """
     SENSE_HAT_EVDEV_NAME = 'Raspberry Pi Sense HAT Joystick'
     EVENT_FORMAT = native_str('llHHI')
     EVENT_SIZE = struct.calcsize(EVENT_FORMAT)
@@ -38,10 +54,17 @@ class SenseStick(object):
     KEY_ENTER = 28
 
     def __init__(self):
-        self._stick_file = io.open(self._stick_device(), 'rb')
+        self._stick_file = io.open(self._stick_device(), 'rb', buffering=0)
+        self._callbacks = {}
+        self._callback_thread = None
+        self._callback_event = Event()
 
     def close(self):
-        self._stick_file.close()
+        if self._stick_file:
+            self._callbacks.clear()
+            self._start_stop_thread()
+            self._stick_file.close()
+            self._stick_file = None
 
     def __enter__(self):
         return self
@@ -49,14 +72,11 @@ class SenseStick(object):
     def __exit__(self, exc_type, exc_value, exc_tb):
         self.close()
 
-    def __iter__(self):
-        while True:
-            event = self._stick_file.read(self.EVENT_SIZE)
-            (tv_sec, tv_usec, type, code, value) = struct.unpack(self.EVENT_FORMAT, event)
-            if type == self.EV_KEY:
-                yield InputEvent(tv_sec + (tv_usec / 1000000), code, value)
-
     def _stick_device(self):
+        """
+        Discovers the filename of the evdev device that represents the Sense
+        HAT's joystick.
+        """
         for evdev in glob.glob('/sys/class/input/event*'):
             try:
                 with io.open(os.path.join(evdev, 'device', 'name'), 'r') as f:
@@ -67,12 +87,222 @@ class SenseStick(object):
                     raise
         raise RuntimeError('unable to locate SenseHAT joystick device')
 
-    def read(self):
-        return next(iter(self))
+    def _read(self):
+        """
+        Reads a single event from the joystick, blocking until one is
+        available. Returns `None` if a non-key event was read, or an
+        `InputEvent` tuple describing the event otherwise.
+        """
+        event = self._stick_file.read(self.EVENT_SIZE)
+        (tv_sec, tv_usec, type, code, value) = struct.unpack(self.EVENT_FORMAT, event)
+        if type == self.EV_KEY:
+            return InputEvent(
+                timestamp=tv_sec + (tv_usec / 1000000),
+                direction={
+                    self.KEY_UP:    DIRECTION_UP,
+                    self.KEY_DOWN:  DIRECTION_DOWN,
+                    self.KEY_LEFT:  DIRECTION_LEFT,
+                    self.KEY_RIGHT: DIRECTION_RIGHT,
+                    self.KEY_ENTER: DIRECTION_MIDDLE,
+                    }[code],
+                action={
+                    self.STATE_PRESS:   ACTION_PRESSED,
+                    self.STATE_RELEASE: ACTION_RELEASED,
+                    self.STATE_HOLD:    ACTION_HELD,
+                    }[value])
+        else:
+            return None
 
-    def wait(self, timeout=None):
-        # XXX Use poll() instead?
+    def _wait(self, timeout=None):
+        """
+        Waits *timeout* seconds until an event is available from the
+        joystick. Returns `True` if an event became available, and `False`
+        if the timeout expired.
+        """
         r, w, x = select.select([self._stick_file], [], [], timeout)
         return bool(r)
 
+    def _wrap_callback(self, fn):
+        # Shamelessley nicked (with some variation) from GPIO Zero :)
+        @wraps(fn)
+        def wrapper(event):
+            return fn()
+
+        if fn is None:
+            return None
+        elif not callable(fn):
+            raise ValueError('value must be None or a callable')
+        elif inspect.isbuiltin(fn):
+            # We can't introspect the prototype of builtins. In this case we
+            # assume that the builtin has no (mandatory) parameters; this is
+            # the most reasonable assumption on the basis that pre-existing
+            # builtins have no knowledge of InputEvent, and the sole parameter
+            # we would pass is an InputEvent
+            return wrapper
+        else:
+            # Try binding ourselves to the argspec of the provided callable.
+            # If this works, assume the function is capable of accepting no
+            # parameters and that we have to wrap it to ignore the event
+            # parameter
+            try:
+                inspect.getcallargs(fn)
+                return wrapper
+            except TypeError:
+                try:
+                    # If the above fails, try binding with a single tuple
+                    # parameter. If this works, return the callback as is
+                    inspect.getcallargs(fn, ())
+                    return fn
+                except TypeError:
+                    raise ValueError(
+                        'value must be a callable which accepts up to one '
+                        'mandatory parameter')
+
+    def _start_stop_thread(self):
+        if self._callbacks and not self._callback_thread:
+            self._callback_event.clear()
+            self._callback_thread = Thread(target=self._callback_run)
+            self._callback_thread.daemon = True
+            self._callback_thread.start()
+        elif not self._callbacks and self._callback_thread:
+            self._callback_event.set()
+            self._callback_thread.join()
+            self._callback_thread = None
+
+    def _callback_run(self):
+        while not self._callback_event.wait(0):
+            event = self._read()
+            if event:
+                callback = self._callbacks.get(event.direction)
+                if callback:
+                    callback(event)
+                callback = self._callbacks.get('*')
+                if callback:
+                    callback(event)
+
+    def wait_for_event(self, emptybuffer=False):
+        """
+        Waits until a joystick event becomes available.  Returns the event, as
+        an `InputEvent` tuple.
+
+        If *emptybuffer* is `True` (it defaults to `False`), any pending
+        events will be thrown away first. This is most useful if you are only
+        interested in "pressed" events.
+        """
+        if emptybuffer:
+            while self._wait(0):
+                self._read()
+        while self._wait():
+            event = self._read()
+            if event:
+                return event
+
+    def get_events(self):
+        """
+        Returns a list of all joystick events that have occurred since the last
+        call to `get_events`. The list contains events in the order that they
+        occurred. If no events have occurred in the intervening time, the
+        result is an empty list.
+        """
+        result = []
+        while self._wait(0):
+            event = self._read()
+            if event:
+                result.append(event)
+        return result
+
+    @property
+    def direction_up(self):
+        """
+        The function to be called when the joystick is pushed up. The function
+        can either take a parameter which will be the `InputEvent` tuple that
+        has occurred, or the function can take no parameters at all.
+        """
+        return self._callbacks.get(DIRECTION_UP)
+
+    @direction_up.setter
+    def direction_up(self, value):
+        self._callbacks[DIRECTION_UP] = self._wrap_callback(value)
+        self._start_stop_thread()
+
+    @property
+    def direction_down(self):
+        """
+        The function to be called when the joystick is pushed down. The
+        function can either take a parameter which will be the `InputEvent`
+        tuple that has occurred, or the function can take no parameters at all.
+
+        Assign `None` to prevent this event from being fired.
+        """
+        return self._callbacks.get(DIRECTION_DOWN)
+
+    @direction_down.setter
+    def direction_down(self, value):
+        self._callbacks[DIRECTION_DOWN] = self._wrap_callback(value)
+        self._start_stop_thread()
+
+    @property
+    def direction_left(self):
+        """
+        The function to be called when the joystick is pushed left. The
+        function can either take a parameter which will be the `InputEvent`
+        tuple that has occurred, or the function can take no parameters at all.
+
+        Assign `None` to prevent this event from being fired.
+        """
+        return self._callbacks.get(DIRECTION_LEFT)
+
+    @direction_left.setter
+    def direction_left(self, value):
+        self._callbacks[DIRECTION_LEFT] = self._wrap_callback(value)
+        self._start_stop_thread()
+
+    @property
+    def direction_right(self):
+        """
+        The function to be called when the joystick is pushed right. The
+        function can either take a parameter which will be the `InputEvent`
+        tuple that has occurred, or the function can take no parameters at all.
+
+        Assign `None` to prevent this event from being fired.
+        """
+        return self._callbacks.get(DIRECTION_RIGHT)
+
+    @direction_right.setter
+    def direction_right(self, value):
+        self._callbacks[DIRECTION_RIGHT] = self._wrap_callback(value)
+        self._start_stop_thread()
+
+    @property
+    def direction_push(self):
+        """
+        The function to be called when the joystick is pressed. The function
+        can either take a parameter which will be the `InputEvent` tuple that
+        has occurred, or the function can take no parameters at all.
+
+        Assign `None` to prevent this event from being fired.
+        """
+        return self._callbacks.get(DIRECTION_MIDDLE)
+
+    @direction_push.setter
+    def direction_push(self, value):
+        self._callbacks[DIRECTION_MIDDLE] = self._wrap_callback(value)
+        self._start_stop_thread()
+
+    @property
+    def direction_any(self):
+        """
+        The function to be called when the joystick is used. The function
+        can either take a parameter which will be the `InputEvent` tuple that
+        has occurred, or the function can take no parameters at all.
+
+        This event will always be called *after* events associated with a
+        specific action. Assign `None` to prevent this event from being fired.
+        """
+        return self._callbacks.get('*')
+
+    @direction_any.setter
+    def direction_any(self, value):
+        self._callbacks['*'] = self._wrap_callback(value)
+        self._start_stop_thread()
 


### PR DESCRIPTION
Modified the SenseStick API to match the new specifiation:

* read and wait are now internal methods
* wait_for_event is now a combination of read and wait
* get_events added to aggregate unread events into a list
* background events added via properties
* added `stick` property to SenseHat class