### PR TITLE
Added timeout parameter to wait_for_event in stick.py

### DIFF
--- a/sense_hat/stick.py
+++ b/sense_hat/stick.py
@@ -180,7 +180,7 @@ class SenseStick(object):
                 if callback:
                     callback(event)
 
-    def wait_for_event(self, emptybuffer=False):
+    def wait_for_event(self, emptybuffer=False, timeout=None):
         """
         Waits until a joystick event becomes available.  Returns the event, as
         an `InputEvent` tuple.
@@ -192,7 +192,7 @@ class SenseStick(object):
         if emptybuffer:
             while self._wait(0):
                 self._read()
-        while self._wait():
+        while self._wait(timeout=timeout):
             event = self._read()
             if event:
                 return event


### PR DESCRIPTION
wait_for_event method can set a timeout after which it will return, by taking an additional default parameter called "timeout".

### Why is this useful:
- To prevent a thread from being blocked on user input, even when there is nothing more to do. This way the thread can check if it must terminate.