### PR TITLE
Added method to clear all outstanding events.

### DIFF
--- a/sense_hat/stick.py
+++ b/sense_hat/stick.py
@@ -197,6 +197,15 @@ class SenseStick(object):
             if event:
                 return event
 
+    def clear_events(self):
+        """
+        Clear all outstanding events
+        """
+
+        while( self._read() != None):
+            pass
+
+
     def get_events(self):
         """
         Returns a list of all joystick events that have occurred since the last


### PR DESCRIPTION
Clearing the outstanding events is useful if you need
to get rid of a button **release** event in preparation for receiving
the next button **press** event. Since the release event happens after
the previous call to wait_for_event() or get_events() it isnt cleared
and will appear in the next call to wait_for_event() or get_events().