### PR TITLE
Bugfix: The "reversed()" function only returns an iterator and not a …

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -319,7 +319,7 @@ sense.clear(255, 127, 0)
 print(sense.gamma)
 time.sleep(2)
 
-sense.gamma = reversed(sense.gamma)
+sense.gamma = list(reversed(sense.gamma))
 print(sense.gamma)
 time.sleep(2)
 


### PR DESCRIPTION
…list (which results to a TypeError if no "list()" is wrapped around).