### PR TITLE
Scale by ceil(max_raw / 256) to prevent out of range colour values

### DIFF
--- a/sense_hat/colour.py
+++ b/sense_hat/colour.py
@@ -316,6 +316,10 @@ class I2C(HardwareInterface):
     get_clear = _raw_wrapper(CDATA)
 
 
+def ceildiv(a, b):
+    return -(a // -b)
+
+
 class ColourSensor:
     
     def __init__(self, gain=1, integration_cycles=1, interface=I2C):
@@ -376,7 +380,7 @@ class ColourSensor:
 
     @property
     def _scaling(self):
-        return self.max_raw // 256
+        return ceildiv(self.max_raw, 256)
     
     @property
     def colour(self):


### PR DESCRIPTION
I was able to get out of range colour values from `sense.color` and noticed that the scaling of colour values allows rbg values up to 257.  

A simple repro script is:

```
from sense_hat import SenseHat
from time import sleep

sense = SenseHat()
sense.set_rotation(270, False)

sense.color.gain = 64 
sense.color.integration_cycles = 64 

while True:
    rgb = sense.color
    c = (rgb.red, rgb.green, rgb.blue)
    print(c, sense.color.color_raw)

    sense.clear(c)

    sleep(1)
```

When you run this and shine a torch at the sensor, you'll see:

```
$ python out_of_range_repro.py 
(1, 1, 1) (300, 301, 277, 693)
(71, 71, 65) (18181, 18240, 16823, 42086)
(70, 71, 65) (18094, 18106, 16740, 41803)
(68, 68, 63) (17384, 17407, 16136, 40250)
(73, 82, 69) (18711, 21028, 17845, 48307)
(257, 257, 257) (65535, 65535, 65535, 65535)
Traceback (most recent call last):
  File "/home/omar/missionzero/out_of_range_repro.py", line 15, in <module>
    sense.clear(c)
  File "/usr/lib/python3/dist-packages/sense_hat/sense_hat.py", line 443, in clear
    self.set_pixels([colour] * 64)
  File "/usr/lib/python3/dist-packages/sense_hat/sense_hat.py", line 318, in set_pixels
    raise ValueError('Pixel at index %d is invalid. Pixel elements must be between 0 and 255' % index)
ValueError: Pixel at index 0 is invalid. Pixel elements must be between 0 and 255
```


I believe it's [this change](https://github.com/astro-pi/python-sense-hat/pull/131/files#diff-5ec8e85c8ed3562a359c152a2697b8bcd835020caec607180578b45a2aae2131R33) where `max_value` changes from `65536` to `65535`, that allows the problem to occur in the `_scaling()` method.

I've adjusted the scaling method to use `ceil(max_raw / 256)`, which for max inputs of `65535` will give a scaling factor of 256 as it would have done prior to #131 .  I used the method ceildiv to avoid extra imports, plus it [seems to be favoured by stackoverflow](https://stackoverflow.com/questions/14822184/is-there-a-ceiling-equivalent-of-operator-in-python/17511341#17511341).

Running the repro again with this change:

```
$ python out_of_range_repro.py 
(1, 1, 0) (270, 273, 254, 629)
(71, 71, 66) (18176, 18321, 16958, 42086)
(73, 73, 68) (18937, 18869, 17424, 43437)
(120, 132, 105) (30785, 33801, 27111, 57861)
(255, 255, 255) (65535, 65535, 65535, 65535)
(255, 255, 255) (65535, 65535, 65535, 65535)
(255, 255, 255) (65535, 65535, 65535, 65535)
(255, 255, 255) (65535, 65535, 65535, 65535)
(255, 255, 255) (65535, 65535, 65535, 65535)
(255, 255, 255) (65535, 65535, 65535, 65535)
```

