### PR TITLE
Add clear_on_exit option to blank LEDs on program termination/SIGINT/SIGTERM/SIGQUIT/SIGHUP

### DIFF
--- a/docs/examples/colour_cycle.py
+++ b/docs/examples/colour_cycle.py
@@ -1,17 +1,8 @@
-#!/usr/bin/python
-import signal
-import sys
+#!/usr/bin/env python
 import time
 from sense_hat import SenseHat
 
-sense = SenseHat()
-
-def clear(signum, frame):
-    sense.clear()
-    sys.exit(0)
-
-signal.signal(signal.SIGINT, clear)
-signal.signal(signal.SIGTERM, clear)
+sense = SenseHat(clear_on_exit=True)
 
 r = 255
 g = 0

--- a/docs/examples/colour_cycle.py
+++ b/docs/examples/colour_cycle.py
@@ -1,8 +1,17 @@
 #!/usr/bin/python
+import signal
+import sys
 import time
 from sense_hat import SenseHat
 
 sense = SenseHat()
+
+def clear(signum, frame):
+    sense.clear()
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, clear)
+signal.signal(signal.SIGTERM, clear)
 
 r = 255
 g = 0

--- a/docs/examples/compass.py
+++ b/docs/examples/compass.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+import signal
 import sys
 from sense_hat import SenseHat
 
@@ -10,6 +11,14 @@ from sense_hat import SenseHat
 led_loop = [4, 5, 6, 7, 15, 23, 31, 39, 47, 55, 63, 62, 61, 60, 59, 58, 57, 56, 48, 40, 32, 24, 16, 8, 0, 1, 2, 3]
 
 sense = SenseHat()
+
+def clear(signum, frame):
+    sense.clear()
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, clear)
+signal.signal(signal.SIGTERM, clear)
+
 sense.set_rotation(0)
 sense.clear()
 

--- a/docs/examples/compass.py
+++ b/docs/examples/compass.py
@@ -1,6 +1,4 @@
-#!/usr/bin/python
-import signal
-import sys
+#!/usr/bin/env python
 from sense_hat import SenseHat
 
 # To get good results with the magnetometer you must first calibrate it using
@@ -10,15 +8,7 @@ from sense_hat import SenseHat
 
 led_loop = [4, 5, 6, 7, 15, 23, 31, 39, 47, 55, 63, 62, 61, 60, 59, 58, 57, 56, 48, 40, 32, 24, 16, 8, 0, 1, 2, 3]
 
-sense = SenseHat()
-
-def clear(signum, frame):
-    sense.clear()
-    sys.exit(0)
-
-signal.signal(signal.SIGINT, clear)
-signal.signal(signal.SIGTERM, clear)
-
+sense = SenseHat(clear_on_exit=True)
 sense.set_rotation(0)
 sense.clear()
 

--- a/docs/examples/rainbow.py
+++ b/docs/examples/rainbow.py
@@ -1,17 +1,8 @@
-#!/usr/bin/python
-import signal
-import sys
+#!/usr/bin/env python
 import time
 from sense_hat import SenseHat
 
-sense = SenseHat()
-
-def clear(signum, frame):
-    sense.clear()
-    sys.exit(0)
-
-signal.signal(signal.SIGINT, clear)
-signal.signal(signal.SIGTERM, clear)
+sense = SenseHat(clear_on_exit=True)
 
 pixels = [
     [255, 0, 0], [255, 0, 0], [255, 87, 0], [255, 196, 0], [205, 255, 0], [95, 255, 0], [0, 255, 13], [0, 255, 122],

--- a/docs/examples/rainbow.py
+++ b/docs/examples/rainbow.py
@@ -1,8 +1,17 @@
 #!/usr/bin/python
+import signal
+import sys
 import time
 from sense_hat import SenseHat
 
 sense = SenseHat()
+
+def clear(signum, frame):
+    sense.clear()
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, clear)
+signal.signal(signal.SIGTERM, clear)
 
 pixels = [
     [255, 0, 0], [255, 0, 0], [255, 87, 0], [255, 196, 0], [205, 255, 0], [95, 255, 0], [0, 255, 13], [0, 255, 122],

--- a/docs/examples/rotation.py
+++ b/docs/examples/rotation.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+import signal
 import sys
 import time
 from sense_hat import SenseHat
@@ -18,6 +19,13 @@ question_mark = [
 ]
 
 sense = SenseHat()
+
+def clear(signum, frame):
+    sense.clear()
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, clear)
+signal.signal(signal.SIGTERM, clear)
 
 sense.set_pixels(question_mark)
 

--- a/docs/examples/rotation.py
+++ b/docs/examples/rotation.py
@@ -1,6 +1,4 @@
-#!/usr/bin/python
-import signal
-import sys
+#!/usr/bin/env python
 import time
 from sense_hat import SenseHat
 
@@ -18,14 +16,7 @@ question_mark = [
     O, O, O, X, O, O, O, O
 ]
 
-sense = SenseHat()
-
-def clear(signum, frame):
-    sense.clear()
-    sys.exit(0)
-
-signal.signal(signal.SIGINT, clear)
-signal.signal(signal.SIGTERM, clear)
+sense = SenseHat(clear_on_exit=True)
 
 sense.set_pixels(question_mark)
 

--- a/docs/examples/space_invader.py
+++ b/docs/examples/space_invader.py
@@ -1,6 +1,11 @@
 #!/usr/bin/python
+import os
+
 from sense_hat import SenseHat
 
 sense = SenseHat()
 sense.clear()
 sense.load_image("space_invader.png")
+
+os.system("bash -c \"read -n 1 -s -p 'Press any key to exit...'\"")
+sense.clear()

--- a/docs/examples/space_invader.py
+++ b/docs/examples/space_invader.py
@@ -1,6 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import os
-
 from sense_hat import SenseHat
 
 sense = SenseHat()

--- a/docs/examples/text_scroll.py
+++ b/docs/examples/text_scroll.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from sense_hat import SenseHat
 
 sense = SenseHat()

--- a/sense_hat/sense_hat.py
+++ b/sense_hat/sense_hat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import logging
 import struct
 import os
@@ -12,6 +12,8 @@ import RTIMU  # custom version
 import pwd
 import array
 import fcntl
+import atexit
+import signal
 from PIL import Image  # pillow
 from copy import deepcopy
 
@@ -33,7 +35,8 @@ class SenseHat(object):
     def __init__(
             self,
             imu_settings_file='RTIMULib',
-            text_assets='sense_hat_text'
+            text_assets='sense_hat_text',
+            clear_on_exit=False
         ):
 
         self._fb_device = self._get_fb_device()
@@ -92,6 +95,17 @@ class SenseHat(object):
         self._gyro_enabled = False
         self._accel_enabled = False
         self._stick = SenseStick()
+        
+        if clear_on_exit:
+            atexit.register(self.clear)
+            for s in (signal.SIGTERM, signal.SIGINT, signal.SIGQUIT, signal.SIGHUP):
+                old_handler = signal.getsignal(s)
+                def handler(signum, frame):
+                    self.clear()
+                    if callable(old_handler):
+                        old_handler(signum, frame)
+                    sys.exit(0)
+                signal.signal(s, handler)
 
         # initialise the TCS34725 colour sensor (if possible)
         try:


### PR DESCRIPTION
This aims to clear the LED array whenever exiting from an example script, so that users do not get stuck with lit pixels upon program termination.  I used `signal` from the Python standard library, so no new packages need to be installed.

Currently I capture SIGINT and SIGTERM, although we can add additional signals if needed.  Nothing we can do if the user sends SIGKILL, though.

**EDIT**: the clear functionality has now been moved to the main module as per @bsimmo's suggestion and the PR title changed.