### PR TITLE
Fix race condition when wait_for_event is used at the same time as direction_up etc.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -672,7 +672,10 @@ or the type of a parameter.
 ### wait_for_event
 
 Blocks execution until a joystick event occurs, then returns an `InputEvent`
-representing the event that occurred.
+representing the event that occurred. 
+
+wait_for_event should not be used at the same time as direction_up, direction_left,
+direction_right, direction_down, direction_middle or direction_any functions.
 
 ```python
 from sense_hat import SenseHat
@@ -709,6 +712,9 @@ print("The joystick was {} {}".format(event.action, event.direction))
 Returns a list of `InputEvent` tuples representing all events that have
 occurred since the last call to `get_events` or `wait_for_event`.
 
+get_events should not be used at the same time as direction_up, direction_left,
+direction_right, direction_down, direction_middle or direction_any functions.
+
 ```python
 from sense_hat import SenseHat
 
@@ -725,6 +731,8 @@ These attributes can be assigned a function which will be called whenever the
 joystick is pushed in the associated direction (or in any direction in the case
 of `direction_any`). The function assigned must either take no parameters or
 must take a single parameter which will be passed the associated `InputEvent`.
+
+These functions should not be used at the same time as wait_for_event or get_events.
 
 ```python
 from sense_hat import SenseHat, ACTION_PRESSED, ACTION_HELD, ACTION_RELEASED

--- a/sense_hat/stick.py
+++ b/sense_hat/stick.py
@@ -189,6 +189,9 @@ class SenseStick(object):
         events will be thrown away first. This is most useful if you are only
         interested in "pressed" events.
         """
+        if self._callbacks:
+            raise RuntimeError('Cannot use wait_for_event when callbacks are assigned')
+        
         if emptybuffer:
             while self._wait(0):
                 self._read()


### PR DESCRIPTION
if you already have a callback assigned to one of the directions ot any and you wait_for_event the first press gets ignored because its read by the callback. 

wait_for_event now raises an error if there is a joystick callback assigned. Also added a warning to the documentation